### PR TITLE
adds name in package.json so that this project can be imported by vue ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "hello-vue-components",
   "private": true,
   "scripts": {
     "dev": "node build-utils/update-index-file.js && vue-cli-service serve",


### PR DESCRIPTION
This PR makes it possible to import this project by using `vue ui`. If you try to import the project now, `vue ui` complains about a missing name. This should probably also be fixed at `vue ui` because the message is only logged to `console`.
![screenshot 2019-02-07 at 10 53 39](https://user-images.githubusercontent.com/153225/52403281-a6b0b300-2ac6-11e9-8001-49dd9d787a46.png)
