### PR TITLE
fix build error when 'vueCliServicePath' has spaces

### DIFF
--- a/build-utils/build-lib.js
+++ b/build-utils/build-lib.js
@@ -16,7 +16,9 @@ require('./update-index-file')
 const componentNames = require('./component-names')
 
 // Get the binary for vue-cli-service
-const vueCliServicePath = getPath('../node_modules/.bin/vue-cli-service')
+const vueCliServicePath = getPath(
+  '../node_modules/.bin/vue-cli-service'
+).replace(/ /g, '\\ ')
 
 fs.emptyDirSync(getPath('../packages'))
 


### PR DESCRIPTION
fixed in build-lib.js, to execute execSync that is vueCliServicePath variable has spaces 